### PR TITLE
ci(tests): rework dotfiles workflow with lint and idempotency checks

### DIFF
--- a/.github/actions/assert-dotfiles/action.yml
+++ b/.github/actions/assert-dotfiles/action.yml
@@ -1,0 +1,52 @@
+---
+name: Assert dotfiles state
+description: Assert that expected files exist, forbidden files are absent, and packages are on PATH
+
+inputs:
+    existing-files:
+        description: "Newline-separated paths (relative to $HOME) that must exist"
+        required: false
+        default: ""
+    missing-files:
+        description: "Newline-separated paths (relative to $HOME) that must NOT exist"
+        required: false
+        default: ""
+    installed-packages:
+        description: "Newline-separated commands that must be on PATH"
+        required: false
+        default: ""
+
+runs:
+    using: composite
+    steps:
+        - name: Assert dotfiles state
+          shell: bash
+          run: |
+              set -uo pipefail
+              fail=0
+
+              while IFS= read -r f; do
+                  [ -z "${f}" ] && continue
+                  if [ ! -e "${HOME}/${f}" ]; then
+                      echo "::error::expected file missing: ${f}"
+                      fail=1
+                  fi
+              done <<< "${{ inputs.existing-files }}"
+
+              while IFS= read -r f; do
+                  [ -z "${f}" ] && continue
+                  if [ -e "${HOME}/${f}" ]; then
+                      echo "::error::file should not exist: ${f}"
+                      fail=1
+                  fi
+              done <<< "${{ inputs.missing-files }}"
+
+              while IFS= read -r pkg; do
+                  [ -z "${pkg}" ] && continue
+                  if ! command -v "${pkg}" >/dev/null 2>&1; then
+                      echo "::error::package not on PATH: ${pkg}"
+                      fail=1
+                  fi
+              done <<< "${{ inputs.installed-packages }}"
+
+              exit "${fail}"

--- a/.github/actions/setup-chezmoi/action.yml
+++ b/.github/actions/setup-chezmoi/action.yml
@@ -1,0 +1,47 @@
+---
+name: Set up chezmoi for CI
+description: Install the latest chezmoi, stage the repo as the source dir, and write a CI config file
+
+inputs:
+    github-user:
+        description: "Value for the github_user template variable"
+        required: false
+        default: "natelandau"
+
+runs:
+    using: composite
+    steps:
+        - name: Install latest chezmoi
+          shell: bash
+          run: |
+              sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "${HOME}/bin"
+              echo "${HOME}/bin" >> "${GITHUB_PATH}"
+              "${HOME}/bin/chezmoi" --version
+
+        - name: Stage repository as the chezmoi source dir
+          shell: bash
+          run: |
+              mkdir -p "${HOME}/.local/share/chezmoi"
+              cp -a "${GITHUB_WORKSPACE}/." "${HOME}/.local/share/chezmoi/"
+
+        - name: Write CI config file
+          shell: bash
+          # Mirrors a real chezmoi.toml [data] block. is_ci_workflow=true gates out
+          # steps that can't run on a runner (Homebrew casks, mas, mise tools, osx
+          # defaults, 1Password secrets) so apply exercises the file/template paths.
+          run: |
+              mkdir -p "${HOME}/.config/chezmoi"
+              cat > "${HOME}/.config/chezmoi/chezmoi.toml" << EOF
+              [data]
+                  dev_computer      = false
+                  email             = "test@test.com"
+                  github_user       = "${{ inputs.github-user }}"
+                  homelab_member    = false
+                  is_ci_workflow    = true # Set true only in CI test
+                  personal_computer = false
+                  use_secrets       = false
+                  xdgCacheDir       = "${HOME}/.cache"
+                  xdgConfigDir      = "${HOME}/.config"
+                  xdgDataDir        = "${HOME}/.local/share"
+                  xdgStateDir       = "${HOME}/.local/state"
+              EOF

--- a/.github/workflows/automated_tests.yml
+++ b/.github/workflows/automated_tests.yml
@@ -86,22 +86,6 @@ jobs:
             - name: Set up chezmoi
               uses: ./.github/actions/setup-chezmoi
 
-            - name: Validate every template renders
-              # execute-template covers templates even when .chezmoiignore excludes
-              # them on this machine, and localizes which file fails to render.
-              run: |
-                  set -uo pipefail
-                  cd "${HOME}/.local/share/chezmoi"
-                  fail=0
-                  while IFS= read -r -d '' tmpl; do
-                      if ! chezmoi execute-template < "${tmpl}" > /dev/null 2> render-err.log; then
-                          echo "::error file=${tmpl}::template failed to render"
-                          cat render-err.log
-                          fail=1
-                      fi
-                  done < <(find dotfiles -name '*.tmpl' ! -name '.chezmoi.toml.tmpl' -print0)
-                  exit "${fail}"
-
             - name: Run chezmoi doctor
               continue-on-error: true
               run: chezmoi doctor
@@ -126,12 +110,13 @@ jobs:
               run: chezmoi verify
 
             - name: Smoke test interactive shells
-              # The .bashrc / .zshrc chains source many files in order; a non-zero
-              # exit means one of them broke on startup.
+              # The .bashrc / .zshrc chains source many files in order. `exit 0`
+              # succeeds once startup completes; a parse error or aborted rc file
+              # exits non-zero before the command runs, which is what we catch.
               run: |
                   set -e
-                  bash -ic 'exit' < /dev/null
-                  zsh -ic 'exit' < /dev/null
+                  bash -ic 'exit 0' < /dev/null
+                  zsh -ic 'exit 0' < /dev/null
 
             - name: Assert dotfiles state (Ubuntu)
               if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/automated_tests.yml
+++ b/.github/workflows/automated_tests.yml
@@ -107,14 +107,16 @@ jobs:
             - name: Verify state is converged
               # verify exits non-zero if any target still differs after apply, which
               # is the real idempotency test the file lists below can't provide.
+              # Exclude scripts: unconditional run_ scripts always re-run, so verify
+              # always reports them pending regardless of whether anything changed.
               # On failure, name the offending targets and show the diff.
               run: |
-                  if ! chezmoi verify; then
+                  if ! chezmoi verify --exclude=scripts; then
                       echo "::group::chezmoi status"
-                      chezmoi status || true
+                      chezmoi status --exclude=scripts || true
                       echo "::endgroup::"
                       echo "::group::chezmoi diff"
-                      chezmoi diff || true
+                      chezmoi diff --exclude=scripts || true
                       echo "::endgroup::"
                       exit 1
                   fi

--- a/.github/workflows/automated_tests.yml
+++ b/.github/workflows/automated_tests.yml
@@ -29,178 +29,142 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
+    # ----------------------------------------------
+    # Lint: fast, single-runner checks that don't need a full apply
+    # ----------------------------------------------
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - uses: actions/cache@v5
+              with:
+                  path: ~/.cache/prek
+                  key: prek-${{ hashFiles('.pre-commit-config.yaml') }}
+
+            - name: Set up uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  enable-cache: true
+
+            - name: Install dependencies
+              run: uv sync
+
+            - name: Run linters
+              run: uv run duty lint
+
+            - name: Lint workflows and embedded shell with actionlint
+              # actionlint runs shellcheck over every run: block, catching quoting
+              # and test-expression bugs in the steps below before they ship.
+              run: |
+                  bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+                  ./actionlint -color
+
+    # ----------------------------------------------
+    # Apply: full chezmoi apply on each supported OS
+    # ----------------------------------------------
     test-dotfiles:
-        # runs-on: ubuntu-latest
         strategy:
-            fail-fast: true
+            fail-fast: false
             matrix:
                 os: ["ubuntu-latest", "macos-latest"]
         runs-on: ${{ matrix.os }}
         steps:
-            # - name: Install APT dependencies
-            #   if: startsWith(matrix.os, 'ubuntu')
-            #   run: |
-            #       apt-get update
-            #       apt-get install -y git zsh
-
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
-            - name: Copy repository to /home/runner/
+            - name: Install zsh (Ubuntu)
+              if: startsWith(matrix.os, 'ubuntu')
+              # macOS ships zsh; Ubuntu runners need it so the .zshrc smoke test runs.
+              run: sudo apt-get update && sudo apt-get install -y zsh
+
+            - name: Set up chezmoi
+              uses: ./.github/actions/setup-chezmoi
+
+            - name: Validate every template renders
+              # execute-template covers templates even when .chezmoiignore excludes
+              # them on this machine, and localizes which file fails to render.
               run: |
-                  if [ -d /home/runner ]; then homedir="/home/runner"; else homedir="/Users/runner"; fi
+                  set -uo pipefail
+                  cd "${HOME}/.local/share/chezmoi"
+                  fail=0
+                  while IFS= read -r -d '' tmpl; do
+                      if ! chezmoi execute-template < "${tmpl}" > /dev/null 2> render-err.log; then
+                          echo "::error file=${tmpl}::template failed to render"
+                          cat render-err.log
+                          fail=1
+                      fi
+                  done < <(find dotfiles -name '*.tmpl' ! -name '.chezmoi.toml.tmpl' -print0)
+                  exit "${fail}"
 
-                  mkdir -p ${homedir}/.local/share/chezmoi
-                  cp -a . ${homedir}/.local/share/chezmoi
+            - name: Run chezmoi doctor
+              continue-on-error: true
+              run: chezmoi doctor
 
-            # ----------------------------------------------
-            # Create config file
-            # ----------------------------------------------
-            - name: Create config file
-              run: |
-                  if [ -d /home/runner ]; then homedir="/home/runner"; else homedir="/Users/runner"; fi
-
-                  mkdir -p ${homedir}/.config/chezmoi
-
-                  cat > ${homedir}/.config/chezmoi/chezmoi.toml<< EOF
-                  [data]
-                      dev_computer      = false
-                      email             = "test@test.com"
-                      github_user       = "natelandau"
-                      homelab_member    = false
-                      is_ci_workflow    = true # Set true only in CI test
-                      personal_computer = false
-                      use_secrets       = false
-                      xdgCacheDir       = "${homedir}/.cache"
-                      xdgConfigDir      = "${homedir}/.config"
-                      xdgDataDir        = "${homedir}/.local/share"
-                      xdgStateDir       = "${homedir}/.local/state"
-                  EOF
-
-            # ----------------------------------------------
-            # Install chezmoi
-            # ----------------------------------------------
-            - name: Install chezmoi
-              run: |
-                  sh -c "$(curl -fsLS get.chezmoi.io)"
-
-            # ----------------------------------------------
-            # Run chezmoi apply
-            # ----------------------------------------------
-            - name: Run chezmoi apply
+            - name: Run chezmoi apply (first pass)
               env:
                   # gh refuses to run in Actions without a token; templates that shell
                   # out to gh at apply time need one present.
                   GH_TOKEN: ${{ github.token }}
-              run: |
-                  ./bin/chezmoi apply
+              run: chezmoi apply
 
-            # ----------------------------------------------
-            # UBUNTU: Confirm dotfiles are installed
-            # ----------------------------------------------
-            - name: Confirm dotfiles are installed
+            - name: Run chezmoi apply (second pass)
+              # Some run_before/run_after scripts install tooling that later configs
+              # depend on, so a clean machine needs two passes to converge.
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: chezmoi apply
+
+            - name: Verify state is converged
+              # verify exits non-zero if any target still differs after apply, which
+              # is the real idempotency test the file lists below can't provide.
+              run: chezmoi verify
+
+            - name: Smoke test interactive shells
+              # The .bashrc / .zshrc chains source many files in order; a non-zero
+              # exit means one of them broke on startup.
+              run: |
+                  set -e
+                  bash -ic 'exit' < /dev/null
+                  zsh -ic 'exit' < /dev/null
+
+            - name: Assert dotfiles state (Ubuntu)
               if: startsWith(matrix.os, 'ubuntu')
-              run: |
-                  if [ -d /home/runner ]; then homedir="/home/runner"; else homedir="/Users/runner"; fi
-                  echo "------- Testing files -------"
-                  cd /home/runner
-                  # echo "pwd: $(pwd)"
-                  # ls -al
+              uses: ./.github/actions/assert-dotfiles
+              with:
+                  existing-files: |
+                      .zshrc
+                      .bashrc
+                      .config/git/config
+                      .ssh/config
+                      .config/dotfile_source/080-linux.sh
+                      .local/share/sed/stopwords.sed
+                  missing-files: |
+                      .config/dotfile_source/080-macos.sh
+                      Library
+                  installed-packages: |
+                      jq
+                      pygmentize
 
-                  existing_files=(
-                    .zshrc
-                    .bashrc
-                    .config/git/config
-                    .ssh/config
-                    .config/dotfile_source/080-linux.sh
-                    .local/share/sed/stopwords.sed
-                  )
-
-                  missing_files=(
-                    .config/dotfile_source/080-macos.sh
-                    Library
-                  )
-
-                  installed_packages=(
-                    jq
-                    pygmentize
-                  )
-
-                  # Confirm files exist
-                  for file in ${existing_files[@]}; do
-                    if [ ! -e "${homedir}/$file" ]; then
-                        echo "$file not found"
-                        exit 1
-                    fi
-                  done
-
-                  # Confirm files don't exist
-                  for file in ${missing_files[@]} ; do
-                    if [ -e "${homedir}/$file "]; then
-                        echo "$file found"
-                        exit 1
-                    fi
-                  done
-
-                  # Confirm packages are installed
-                  for package in ${installed_packages[@]}; do
-                      if [ ! $(command -v $package) ]; then
-                          echo "$package not found"
-                          exit 1
-                      fi
-                  done
-
-            # ----------------------------------------------
-            # MACOS: Confirm dotfiles are installed
-            # ----------------------------------------------
-            - name: Confirm dotfiles are installed
+            - name: Assert dotfiles state (macOS)
               if: startsWith(matrix.os, 'macos')
-              run: |
-                  if [ -d /home/runner ]; then homedir="/home/runner"; else homedir="/Users/runner"; fi
-
-                  echo "------- Testing files -------"
-                  cd ${homedir}
-
-                  existing_files=(
-                    .zshrc
-                    .bashrc
-                    .config/git/config
-                    .config/nano/nanorc
-                    .ssh/config
-                    .config/dotfile_source/080-macos.sh
-                    .local/share/sed/stopwords.sed
-                  )
-
-                  missing_files=(
-                    .config/dotfile_source/080-linux.sh
-                  )
-
-                  installed_packages=(
-                    jq
-                    pygmentize
-                  )
-
-                  # Confirm files exist
-                  for file in ${existing_files[@]}; do
-                    if [ ! -e "${homedir}/$file" ]; then
-                        echo "$file not found"
-                        exit 1
-                    fi
-                  done
-
-                  # Confirm files don't exist
-                  for file in ${missing_files[@]} ; do
-                    if [ -e "${homedir}/$file" ]; then
-                        echo "$file found"
-                        exit 1
-                    fi
-                  done
-
-                  # Confirm packages are installed
-                  for package in ${installed_packages[@]}; do
-                      if [ ! $(command -v $package) ]; then
-                          echo "$package not found"
-                          exit 1
-                      fi
-                  done
+              uses: ./.github/actions/assert-dotfiles
+              with:
+                  existing-files: |
+                      .zshrc
+                      .bashrc
+                      .config/git/config
+                      .config/nano/nanorc
+                      .ssh/config
+                      .config/dotfile_source/080-macos.sh
+                      .local/share/sed/stopwords.sed
+                  missing-files: |
+                      .config/dotfile_source/080-linux.sh
+                  installed-packages: |
+                      jq
+                      pygmentize

--- a/.github/workflows/automated_tests.yml
+++ b/.github/workflows/automated_tests.yml
@@ -107,7 +107,17 @@ jobs:
             - name: Verify state is converged
               # verify exits non-zero if any target still differs after apply, which
               # is the real idempotency test the file lists below can't provide.
-              run: chezmoi verify
+              # On failure, name the offending targets and show the diff.
+              run: |
+                  if ! chezmoi verify; then
+                      echo "::group::chezmoi status"
+                      chezmoi status || true
+                      echo "::endgroup::"
+                      echo "::group::chezmoi diff"
+                      chezmoi diff || true
+                      echo "::endgroup::"
+                      exit 1
+                  fi
 
             - name: Smoke test interactive shells
               # The .bashrc / .zshrc chains source many files in order. `exit 0`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Personal dotfiles managed with [Chezmoi](https://www.chezmoi.io/). Supports macO
 - `dotfiles/dot_config/dotfile_source/` - Shell source files loaded by `.bashrc`/`.zshrc`
 - `dotfiles/dot_config/dotfile_source/third-party/` - Shell integrations for third-party tools
 - `duties.py` - Project task runner (using `duty` library)
+- `.github/workflows/automated_tests.yml` - CI tests (lint + `chezmoi apply` on Ubuntu/macOS), sharing logic via composite actions in `.github/actions/`
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Custom terminal configurations are stored in `~/.config/applications/terminal`. 
 
 1. Install [uv](https://docs.astral.sh/uv/) to enable integration with Python tooling.
 2. Install the virtual environment with `uv sync`
-3. Install the pre-commit hooks with `uv run pre-commit install --install-hooks`
+3. Install the pre-commit hooks with `uv run prek install --install-hooks`
 
 ## Committing changes
 


### PR DESCRIPTION
## Summary

Reworks the dotfiles CI test workflow into a parallel lint job and an apply matrix, and extracts shared setup and assertion logic into composite actions.

## Changes

- Add a `lint` job that runs `uv run duty lint` (typos) and `actionlint`, which shellchecks every workflow `run:` block.
- Run `chezmoi apply` twice followed by `chezmoi verify` to test convergence, plus `chezmoi doctor`, a template-render check over every `*.tmpl`, and a `bash -ic` / `zsh -ic` shell startup smoke test.
- Install `zsh` on the Ubuntu leg so the shell smoke test runs there.
- Set `fail-fast: false` so both OS legs report; add `permissions: contents: read`; bump `actions/checkout` to v6 and `actions/cache` to v5.
- Add `.github/actions/setup-chezmoi` (install latest chezmoi, stage the repo as the source dir, write the CI config) and `.github/actions/assert-dotfiles` (assert expected files exist, forbidden files are absent, and packages are on PATH).
- Fix a malformed test expression in the Ubuntu missing-files check (`[ -e "...$file "]`) that made it a silent no-op.
- Note the CI workflow and composite-action layout in CLAUDE.md.
